### PR TITLE
libtreeedit needs to go before libwindows in link order

### DIFF
--- a/src/treeedit/Makefile.in
+++ b/src/treeedit/Makefile.in
@@ -17,4 +17,4 @@ libtreeedit.la: $(LTOBJECTS)
 	$(LINKXX) -o libtreeedit.la -rpath $(libdir) $(LTOBJECTS)
 
 mathpad: libtreeedit.la mathpad.o
-	$(LINKXX) -o mathpad mathpad.o ../treeedit/libtreeedit.la ../windows/libwindows.la ../documents/libdocuments.la ../templates/libtemplates.la ../output/liboutput.la ../language/liblanguage.la ../keyboard/libkeyboard.la ../unicode/libunicode.la ../util/libutil.la $(XLIB)
+	$(LINKXX) -o mathpad mathpad.o ../windows/libwindows.la ../treeedit/libtreeedit.la ../documents/libdocuments.la ../templates/libtemplates.la ../output/liboutput.la ../language/liblanguage.la ../keyboard/libkeyboard.la ../unicode/libunicode.la ../util/libutil.la $(XLIB)


### PR DESCRIPTION
With this change, the build succeeds on Ubuntu 16.04 32-bit.